### PR TITLE
Implement update() as write() ensuring one

### DIFF
--- a/openerp/models.py
+++ b/openerp/models.py
@@ -5328,8 +5328,8 @@ class BaseModel(object):
 
     def update(self, values):
         """ Update record `self[0]` with `values`. """
-        for name, value in values.iteritems():
-            self[name] = value
+        self.ensure_one()
+        self.write(values)
 
     #
     # New records - represent records that do not exist in the database yet;


### PR DESCRIPTION
At the moment update(many_fields) causes a separate call to write() (and hence all of its hooks and overrides) for each field in the dict many_fields, which is inefficient and significantly slowed down an import routine that used it to 8 seconds per product instead of 0.3s per product.

The purpose of update() is not specified in the main documentation here: https://www.odoo.com/documentation/8.0/reference/orm.html

Apart from performance, the only externally visible semantics I can see are that recset.update() raises an exception if len(recset) != 0 whereas write() works on 0 to many records.

This pull request changes update() to use ensure_one() followed by write(), so the visible semantics are the same without killing performance.

Of course if there's a good reason for update() to be implemented as a series of rec[field] = value I'd be interested to know what it is.
